### PR TITLE
Fix floating point number regexp

### DIFF
--- a/rego-mode.el
+++ b/rego-mode.el
@@ -71,7 +71,7 @@
 
 (defconst rego-mode-constants (regexp-opt '("true" "false" "null") 'symbols))
 (defconst rego-mode-numerals "\\_<[+\\-][1-9]+\\_>")
-(defconst rego-mode-doubles "\\_<[+\\-]?[0-9]+\.[0-9]+\\_>")
+(defconst rego-mode-doubles "\\_<[+\\-]?[0-9]+\\.[0-9]+\\_>")
 (defconst rego-mode-operators (regexp-opt '("==" "!=" "<" ">" "<=" ">=" "+" "-" "*" "/" "&" "|" "=" ":=")))
 (defconst rego-mode-variables "\\([a-zA-Z][][a-zA-Z0-9_]*\\)[[:space:]]*= ")
 (defconst rego-mode-restricted-variables "\\([a-zA-Z][a-zA-Z0-9_]*\\)[[:space:]]*:= ")


### PR DESCRIPTION
### Original Code

![before](https://user-images.githubusercontent.com/554281/97866338-1bbe2480-1d4f-11eb-8061-b0c206d45f42.png)

In original code, `\.`  is treated as meta character  `.` (It matches any character)

### This PR version

![after](https://user-images.githubusercontent.com/554281/97866351-211b6f00-1d4f-11eb-85f8-8b9e00a72e15.png)

`\\.` only match against `.` character
